### PR TITLE
Remove unnecessary cache clear on initialisation

### DIFF
--- a/jimmypage/cache.py
+++ b/jimmypage/cache.py
@@ -149,4 +149,3 @@ else:
     def debug(*args):
         pass
 
-clear_cache()


### PR DESCRIPTION
As mentioned in #5 this doesn't play nicely with scheduled management commands and removing it seems fairly safe.
