### PR TITLE
ETags causing problems in Chrome

### DIFF
--- a/jimmypage/cache.py
+++ b/jimmypage/cache.py
@@ -103,9 +103,9 @@ class cache_page(object):
             if response_is_cacheable(request, response):
                 debug("storing!")
                 cache.set(key, response.content, self.time)
+                response["ETag"] = key
             else:
                 debug("Not storable.")
-            response["ETag"] = key
             return response 
         debug("Not retrievable.")
         debug("generating!")


### PR DESCRIPTION
We were having a problem with Chrome where we were getting a 403 response even when the JimmyPage was set to not cache this page. We traced the problem down to ETags and this was our fix. I can supply more info if this isn't enough to reproduce the problem.
